### PR TITLE
service(processor): implement real-time monitoring and filtering logic

### DIFF
--- a/services/stream-processor-service/internal/services/processor.go
+++ b/services/stream-processor-service/internal/services/processor.go
@@ -1,10 +1,15 @@
 package processorService
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"leviathan-wake-cockpit/internal/config"
 	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"leviathan-wake-cockpit/internal/config"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/gorilla/websocket"
@@ -20,14 +25,37 @@ type WhitelistEntry struct {
 type ProcessorService struct {
 	cfg         *config.Config
 	keydbClient *redis.Client
+	httpClient  *http.Client
 	whitelist   map[string]bool
 	// grpcClient
+}
+
+type InfuraSubscriptionMessage struct {
+	Params struct {
+		Subscription string `json:"subscription"`
+		Result       string `json:"result"`
+	} `json:"params"`
+}
+
+type JSONRPCRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      int           `json:"id"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+type TransactionDetailsResponse struct {
+	Result *struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"result"`
 }
 
 func NewProcessorService(cfg *config.Config, db *redis.Client) *ProcessorService {
 	return &ProcessorService{
 		cfg:         cfg,
 		keydbClient: db,
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
 		whitelist:   make(map[string]bool),
 	}
 }
@@ -35,13 +63,24 @@ func NewProcessorService(cfg *config.Config, db *redis.Client) *ProcessorService
 func (s *ProcessorService) Start(ctx context.Context) {
 	log.Println("StreamProcessorService (Hot Path) has started...")
 
-	// TODO
-	err := s.loadWhitelistFromKeyDB(ctx)
-	if err != nil {
-		log.Printf("WARN: Could not load initial whitelist: %v. Will retry...", err)
+	for {
+		if err := s.loadWhitelistFromKeyDB(ctx); err == nil {
+			break
+		}
+		log.Printf("WARN: Could not load initial whitelist. Retrying in 10 seconds...")
+		time.Sleep(10 * time.Second)
 	}
 
-	s.connectAndListen()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			s.connectAndListen()
+			log.Println("Connection lost. Reconnecting in 5 seconds...")
+			time.Sleep(5 * time.Second)
+		}
+	}
 }
 
 func (s *ProcessorService) loadWhitelistFromKeyDB(ctx context.Context) error {
@@ -94,7 +133,7 @@ func (s *ProcessorService) connectAndListen() {
 	defer conn.Close()
 	log.Println("Successfully connected to Arbitrum WebSocket.")
 
-	subscribeMsg := `{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["alchemy_newPendingTransactions"]}`
+	subscribeMsg := `{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newPendingTransactions"]}`
 	if err := conn.WriteMessage(websocket.TextMessage, []byte(subscribeMsg)); err != nil {
 		log.Fatalf("FATAL: Could not subscribe to new transactions: %v", err)
 	}
@@ -112,5 +151,51 @@ func (s *ProcessorService) connectAndListen() {
 }
 
 func (s *ProcessorService) processTransactionMessage(msg []byte) {
-	// TODO
+	var subMsg InfuraSubscriptionMessage
+	if err := json.Unmarshal(msg, &subMsg); err != nil || subMsg.Params.Result == "" {
+		return
+	}
+
+	txHash := subMsg.Params.Result
+
+	txDetails, err := s.fetchTransactionDetails(txHash)
+	if err != nil || txDetails.Result == nil {
+		return
+	}
+
+	from := strings.ToLower(txDetails.Result.From)
+	to := strings.ToLower(txDetails.Result.To)
+
+	if s.whitelist[from] || s.whitelist[to] {
+		log.Printf("✅ !!! WHALE TRANSACTION DETECTED !!! Hash: %s, From: %s, To: %s", txHash, from, to)
+	}
+}
+
+func (s *ProcessorService) fetchTransactionDetails(hash string) (*TransactionDetailsResponse, error) {
+	httpURL := strings.Replace(s.cfg.ArbitrumWsUrl, "wss://", "https://", 1)
+	httpURL = strings.Replace(httpURL, "/ws/", "/", 1)
+
+	payload := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "eth_getTransactionByHash",
+		Params:  []interface{}{hash},
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", httpURL, bytes.NewBuffer(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var txResp TransactionDetailsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&txResp); err != nil {
+		return nil, err
+	}
+
+	return &txResp, nil
 }


### PR DESCRIPTION
- Loads whale whitelist from KeyDB into an in-memory map for high-speed lookups.
- Establishes a persistent WebSocket connection to the Arbitrum node and subscribes to new pending transactions.
- For each received transaction hash, fetches full details (from, to) via an HTTP RPC call.
- Filters transactions against the whitelist and logs detected whale activity.